### PR TITLE
Add hooks for managing columns and column data in admin table and export

### DIFF
--- a/admin/wpcl-api.php
+++ b/admin/wpcl-api.php
@@ -224,6 +224,9 @@ class Wpcl_Api
                 $columns[$option_name] = $option_values['column_pretty_name'];
             }
         }
+
+        $columns = apply_filters('wpcl_admin_columns', $columns, $orders);
+
         foreach ( $orders as $order_info ) {
             $order_id = $order_info['order_id'];
             $item_id = $order_info['order_item_id'];
@@ -418,6 +421,9 @@ class Wpcl_Api
             if ( $order->get_billing_email() ) {
                 $data['email_list'][] = $order->get_billing_email();
             }
+
+            $current_row = apply_filters('wpcl_admin_current_row', $current_row, $order, $item_id);
+
             $data['data'][] = $current_row;
         }
         if ( !empty($data['email_list']) ) {


### PR DESCRIPTION
We recently purchased the premium version of the plugin due to the fact that the premium plugin touted "Support for Custom Fields". Unfortunately, we quickly found out that our order item meta was not available in the list of available custom fields.

I reviewed the list of available actions and filters by scanning the codebase and while I did find a couple defined actions, they were all for the shortcode and not for the admin table.

In the fork of the plugin, I was able to add two filters easily which I think would greatly increase the versatility of this plugin and support more complex use cases. You can see how I applied the added filters here:

```php
/**
 * Add custom columns to WC Product Customer List plugin
 *
 * @see plugins/wc-product-customer-list/admin/wpcl-api.php
 */
add_filter('wpcl_admin_columns', function ($columns) {
    unset($columns['wpcl_variations']);
    $columns['il_student_name'] = 'Student Name';
    $columns['il_student_email'] = 'Student Email';
    $columns['il_producer_license_no'] = 'Prod. License #';
    return $columns;
}, 10, 1);

/**
 * Add column data for row to WC Product Customer List plugin
 *
 * @see plugins/wc-product-customer-list/admin/wpcl-api.php
 */
add_filter('wpcl_admin_current_row', function ($current_row, $order, $item_id) {
    $order_item = $order->get_item($item_id);

    $current_row['il_student_name'] = $order_item->get_meta('Student Name');
    $current_row['il_student_email'] = $order_item->get_meta('Student Email');
    $current_row['il_producer_license_no'] = $order_item->get_meta('Producer License Number');

    return $current_row;
}, 10, 3);
``` 

Would be great to see this merged into the core version of the plugin so we don't have to maintain a fork.